### PR TITLE
fix: validate clone name inputs and harden SQL

### DIFF
--- a/list_cloner_admin.php
+++ b/list_cloner_admin.php
@@ -359,9 +359,9 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
         $flag = 1;
         while ($continue === false) {
             if($flag == 1) {
-                $db->setQuery("SHOW TABLES LIKE '{$name}'");
+                $db->setQuery('SHOW TABLES LIKE ' . $db->quote($name));
             } else {
-                $db->setQuery("SHOW TABLES LIKE '{$name}_{$flag}'");
+                $db->setQuery('SHOW TABLES LIKE ' . $db->quote($name . '_' . $flag));
             }
             $result = $db->loadResult();
             if ($result) {
@@ -795,7 +795,7 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
                 $tableName = $this->clones_info[$listId]->db_table_name . "_" . $obj->group_id . "_repeat";
                 $oldTableName = $this->clones_info[$listId]->old_db_table_name . "_" . $oldId . "_repeat";
 
-                $db->setQuery("CREATE TABLE $tableName LIKE $oldTableName");
+                $db->setQuery('CREATE TABLE ' . $db->quoteName($tableName) . ' LIKE ' . $db->quoteName($oldTableName));
 
                 $cloneDataJoins = new stdClass();
                 $cloneDataJoins->id = 0;
@@ -867,7 +867,7 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
             $params = json_decode($cloneData->params);
             if ($cloneData->plugin === 'databasejoin') {
                 $query = $db->getQuery(true);
-                $query->select('id')->from($this->prefix . "fabrik_lists")->where("db_table_name = '{$params->join_db_name}'");
+                $query->select('id')->from($this->prefix . "fabrik_lists")->where($db->quoteName('db_table_name') . ' = ' . $db->quote($params->join_db_name));
                 $db->setQuery($query);
                 $res = $db->loadResult();
                 if (in_array($res, $fields_adm->listas_auxiliares)) {
@@ -875,7 +875,7 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
                     $continue = false;
                     $flag = 1;
                     while ($continue === false) {
-                        $db->setQuery("SHOW TABLES LIKE '{$new_table_name}_{$flag}'");
+                        $db->setQuery('SHOW TABLES LIKE ' . $db->quote($new_table_name . '_' . $flag));
                         $result = $db->loadResult();
                         if ($result) {
                             $flag++;
@@ -1070,7 +1070,7 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
         $tableName = $this->clones_info[$listId]->db_table_name;
         $oldTableName = $this->clones_info[$listId]->old_db_table_name;
 
-        $db->setQuery("CREATE TABLE $tableName LIKE $oldTableName");
+        $db->setQuery('CREATE TABLE ' . $db->quoteName($tableName) . ' LIKE ' . $db->quoteName($oldTableName));
         try
         {
             $db->execute();
@@ -1100,7 +1100,7 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
             $cloneTable = $tableName . '_repeat_' . $element;
             $table = $oldTableName . '_repeat_' . $element;
 
-            $db->setQuery("CREATE TABLE $cloneTable LIKE $table");
+            $db->setQuery('CREATE TABLE ' . $db->quoteName($cloneTable) . ' LIKE ' . $db->quoteName($table));
             try
             {
                 $db->execute();
@@ -1399,7 +1399,7 @@ class PlgFabrik_FormList_cloner_admin extends PlgFabrik_Form
         $continue = false;
         $flag = 1;
         while ($continue === false) {
-            $db->setQuery("SHOW TABLES LIKE '{$name}_{$flag}'");
+            $db->setQuery('SHOW TABLES LIKE ' . $db->quote($name . '_' . $flag));
             $result = $db->loadResult();
             if ($result) {
                 $flag++;

--- a/list_cloner_names.php
+++ b/list_cloner_names.php
@@ -17,9 +17,20 @@
 	use Joomla\CMS\Factory;
 
 	// Dados do Form e Pré Estabelecidos //
-	$idTableModel = $_GET['tableModel'];
-	$idlista = $_GET['listid'];
-	$listModel = $_GET['listModel'];
+	$app = Factory::getApplication();
+	$input = $app->getInput();
+	$idTableModel = $input->getInt('tableModel');
+	$idlista = $input->getInt('listid');
+	$listModel = $input->getCmd('listModel');
+
+	if ($idTableModel <= 0 || $idlista <= 0 || !preg_match('/^[A-Za-z0-9_]+$/', $listModel)) {
+		http_response_code(400);
+		echo json_encode([
+			"sucesso" => "",
+			"erro" => "Parametros invalidos",
+		]);
+		exit;
+	}
 
 	// Ligação ao banco de dados //	
 	$db = Factory::getDbo();
@@ -29,7 +40,7 @@
 	$query->clear()
 		  ->select($db->quoteName('db_table_name') . 'AS tabelaListaModelo')
 		  ->from($db->quoteName($prefix . 'fabrik_lists') . 'AS l')
-		  ->where('l.id = "' . $idlista . '"');
+		  ->where($db->quoteName('l.id') . ' = ' . (int) $idlista);
 
 	$db->setQuery($query);
 	$result = $db->loadObject();
@@ -51,16 +62,18 @@
 		  ->join('LEFT', $db->quoteName($listModel . '_repeat_extra_lists') . 'AS e ON m.id = e.parent_id')
 		  ->join('LEFT', $db->quoteName($prefix . 'fabrik_lists') . 'AS l ON e.extra_lists = l.id')
 		  ->join('LEFT', $db->quoteName($prefix . 'fabrik_lists') . 'AS le ON m.main_list = le.id')
-		  ->where('m.id = "' . $idTableModel . '"');
+		  ->where($db->quoteName('m.id') . ' = ' . (int) $idTableModel);
 
 	$db->setQuery($query);
 	$result = $db->loadObjectList();
 	
-	$nomeListaModelo = $result['0']->nomeListaModelo;
-	$usuario = $result['0']->idUsuario;
-	$nomeListaPrincipal = $result['0']->nomeListaPrincipal;
-	$idListaPrincipal = $result['0']->idListaPrincipal;
-	$nomeTablePrincipal = $result['0']->nomeTablePrincipal;
+	if (!empty($result)) {
+		$nomeListaModelo = $result['0']->nomeListaModelo;
+		$usuario = $result['0']->idUsuario;
+		$nomeListaPrincipal = $result['0']->nomeListaPrincipal;
+		$idListaPrincipal = $result['0']->idListaPrincipal;
+		$nomeTablePrincipal = $result['0']->nomeTablePrincipal;
+	}
 
 	$resultExtras = array();
 	foreach($result as $key => $relacao) {
@@ -100,7 +113,7 @@
         $continue = false;
         $flag = 1;
         while ($continue === false) {
-            $db->setQuery("SHOW TABLES LIKE '{$name}_{$flag}'");
+            $db->setQuery('SHOW TABLES LIKE ' . $db->quote($name . '_' . $flag));
             $result = $db->loadResult();
             if ($result) {
                 $flag++;


### PR DESCRIPTION
## Summary

This PR hardens the Joomla/Fabrik admin cloning plugin against SQL injection risks.

Changes include:

- Validate request parameters before using them
- Replace direct `$_GET` access with Joomla input filtering
- Quote dynamic values used in `SHOW TABLES LIKE`
- Quote dynamic table identifiers used in `CREATE TABLE ... LIKE ...`
- Quote database comparisons such as IDs and `db_table_name`
- Preserve existing Joomla/Fabrik cloning behavior
